### PR TITLE
No PF muon post Cleaning

### DIFF
--- a/PFChargedHadronAnalyzer/test/run_CMSSW.pbs
+++ b/PFChargedHadronAnalyzer/test/run_CMSSW.pbs
@@ -1,0 +1,16 @@
+#!/bin/bash
+#PBS -l nodes=1:ppn=36
+#PBS -m ea
+
+# setup cmssw environment
+cd $PBS_O_WORKDIR
+pwd
+source ~cmssoft/shrc
+eval `scramv1 runtime -sh`
+
+# read user proxy
+#export X509_USER_PROXY=/cms/data/$USER/.x509_user_proxy
+
+# run your job
+cmsRun step3_RAW2DIGI_L1Reco_RECO_RECOSIM_EI_PAT_VALIDATION_DQM.py
+

--- a/PFChargedHadronAnalyzer/test/step3_RAW2DIGI_L1Reco_RECO_RECOSIM_EI_PAT_VALIDATION_DQM.py
+++ b/PFChargedHadronAnalyzer/test/step3_RAW2DIGI_L1Reco_RECO_RECOSIM_EI_PAT_VALIDATION_DQM.py
@@ -1,7 +1,7 @@
 # Auto generated configuration file
-# using: 
-# Revision: 1.19 
-# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# using:
+# Revision: 1.19
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v
 # with command line options: step2 --mc --eventcontent RECOSIM --datatier GEN-SIM-RECO --conditions 120X_mcRun3_2021_realistic_v6 --step RAW2DIGI,L1Reco,RECO,RECOSIM --nThreads 4 --geometry DB:Extended --era Run3 --filein file:JME-Run3Summer21DRPremix-00001_1_1.root --fileout file:JME-Run3Summer21DRPremix-00001_2_1.root -n -1
 import FWCore.ParameterSet.Config as cms
 
@@ -106,49 +106,48 @@ process.pfChargedHadronAnalyzer = cms.EDAnalyzer(
     HcalPFClusters = cms.InputTag("particleFlowClusterHCAL"),
     EcalPFrechit = cms.InputTag("particleFlowRecHitECAL"),
     HcalPFrechit = cms.InputTag("particleFlowRecHitHBHE"),
-    ptMin = cms.double(1.),                     # Minimum pt                                                                         
-    pMin = cms.double(1.),                      # Minimum p                                                                          
-    nPixMin = cms.int32(2),                     # Nb of pixel hits                                                                   
-    nHitMin = cms.vint32(14,17,20,17,10),       # Nb of track hits                                                                   
-    nEtaMin = cms.vdouble(1.4,1.6,2.0,2.4,2.6), # in these eta ranges                                                                
-    hcalMin = cms.double(0.5),                   # Minimum hcal energy                                                               
-    ecalMax = cms.double(1E9),                  # Maximum ecal energy                                                                
-    verbose = cms.untracked.bool(True),         # not used.                                                                          
-    #rootOutputFile = cms.string("PGun__2_200GeV__81X_upgrade2017_realistic_v22.root"),# the root tree                               
-    rootOutputFile = cms.string("step3.root"),# the root tree                                                       
-#    IsMinBias = cms.untracked.bool(False)                                                                                           
+    ptMin = cms.double(1.),                     # Minimum pt
+    pMin = cms.double(1.),                      # Minimum p
+    nPixMin = cms.int32(2),                     # Nb of pixel hits
+    nHitMin = cms.vint32(14,17,20,17,10),       # Nb of track hits
+    nEtaMin = cms.vdouble(1.4,1.6,2.0,2.4,2.6), # in these eta ranges
+    hcalMin = cms.double(0.5),                   # Minimum hcal energy
+    ecalMax = cms.double(1E9),                  # Maximum ecal energy
+    verbose = cms.untracked.bool(True),         # not used.
+    #rootOutputFile = cms.string("PGun__2_200GeV__81X_upgrade2017_realistic_v22.root"),# the root tree
+    rootOutputFile = cms.string("step3.root"),# the root tree
+#    IsMinBias = cms.untracked.bool(False)
 )
 
-
-
-
 process.load("RecoParticleFlow.PFProducer.particleFlowSimParticle_cff")
-#process.load("RecoParticleFlow.Configuration.HepMCCopy_cfi")                                                                        
+#process.load("RecoParticleFlow.Configuration.HepMCCopy_cfi")
 
 process.particleFlowSimParticle.ParticleFilter = cms.PSet(
-        # Allow *ALL* protons with energy > protonEMin                                                                               
+        # Allow *ALL* protons with energy > protonEMin
         protonEMin = cms.double(5000.0),
-        # Particles must have abs(eta) < etaMax (if close enough to 0,0,0)                                                           
+        # Particles must have abs(eta) < etaMax (if close enough to 0,0,0)
         etaMax = cms.double(5.3),
-        # Charged particles with pT < pTMin (GeV/c) are not simulated                                                                
+        # Charged particles with pT < pTMin (GeV/c) are not simulated
         chargedPtMin = cms.double(0.0),
-        # Particles must have energy greater than EMin [GeV]                                                                         
+        # Particles must have energy greater than EMin [GeV]
         EMin = cms.double(0.0),
         rMax = cms.double(129.),
-        # half-length of the ECAL endcap inner surface 
+        # half-length of the ECAL endcap inner surface
         zMax = cms.double(317.),
         # List of invisible particles (abs of pdgid)
         invisibleParticles = cms.vint32()
 )
 
-process.genReReco = cms.Sequence(#process.generator+                                                                                 
-                                 #process.genParticles+                                                                              
-                                 #process.genJetParticles+                                                                           
-                                 #process.recoGenJets+                                                                               
-                                 #process.genMETParticles+                                                                           
-                                 #process.recoGenMET+                                                                                
-process.particleFlowSimParticle)
+# Turn off PFMuon postcleaning
+process.particleFlowTmp.postMuonCleaning = False
 
+process.genReReco = cms.Sequence(#process.generator+
+                                 #process.genParticles+
+                                 #process.genJetParticles+
+                                 #process.recoGenJets+
+                                 #process.genMETParticles+
+                                 #process.recoGenMET+
+process.particleFlowSimParticle)
 
 # Path and EndPath definitions
 process.raw2digi_step = cms.Path(process.RawToDigi)
@@ -172,8 +171,6 @@ process.options.numberOfStreams = 0
 process.options.numberOfConcurrentLuminosityBlocks = 2
 process.options.eventSetup.numberOfConcurrentIOVs = 1
 if hasattr(process, 'DQMStore'): process.DQMStore.assertLegacySafe=cms.untracked.bool(False)
-
-
 
 # Customisation from command line
 

--- a/PFChargedHadronAnalyzer/test/step3_RAW2DIGI_L1Reco_RECO_RECOSIM_EI_PAT_VALIDATION_DQM.py
+++ b/PFChargedHadronAnalyzer/test/step3_RAW2DIGI_L1Reco_RECO_RECOSIM_EI_PAT_VALIDATION_DQM.py
@@ -25,7 +25,7 @@ process.load('Configuration.StandardSequences.EndOfProcess_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(10000), #NEvents
+    input = cms.untracked.int32(-1), #NEvents
     output = cms.optional.untracked.allowed(cms.int32,cms.PSet)
 )
 
@@ -33,7 +33,8 @@ process.maxEvents = cms.untracked.PSet(
 process.source = cms.Source("PoolSource",
 #    fileNames = cms.untracked.vstring('file:JME-Run3Summer21DRPremix-00001_1_1.root'),
                             #    fileNames = cms.untracked.vstring('root://se01.indiacms.res.in//store/user/bkansal/step2/PGun_step2_DIGI_1200_2021_2_200_Sep17_tmp/CRAB_UserFiles/crab_PGun_step2_DIGI_1200_2021_2_200_Sep17_tmp/210918_034925/0000/step2_99.root'),
-      fileNames = cms.untracked.vstring('root://cms-xrd-global.cern.ch//store/mc/Run3Winter23Digi/SinglePionGun_E200to500/GEN-SIM-RAW/NoPUGTv4_126X_mcRun3_2023_forPU65_v4-v2/50000/00161083-8bd0-4a00-b462-c5e5141ab85c.root'),
+      #fileNames = cms.untracked.vstring('root://cms-xrd-global.cern.ch//store/mc/Run3Winter23Digi/SinglePionGun_E200to500/GEN-SIM-RAW/NoPUGTv4_126X_mcRun3_2023_forPU65_v4-v2/50000/00161083-8bd0-4a00-b462-c5e5141ab85c.root'),
+      fileNames = cms.untracked.vstring('/store/mc/Run3Winter23Digi/SinglePionGun_E200to500/GEN-SIM-RAW/NoPUGTv4_126X_mcRun3_2023_forPU65_v4-v2/50000/00161083-8bd0-4a00-b462-c5e5141ab85c.root'),
 #     fileNames = cms.untracked.vstring('root://eos.cms.rcac.purdue.edu:1094//store/mc/Run3Winter23Digi/SinglePionGun_E0p2to200/GEN-SIM-RAW/NoPUGTv4_126X_mcRun3_2023_forPU65_v4-v2/30000/69d9ccbd-2571-4611-bae5-c36a13f83ec9.root'),
 #     fileNames = cms.untracked.vstring('root://cms-xrd-global.cern.ch//store/mc/Run3Winter23Digi/SinglePionGun_E0p2to200/GEN-SIM-RAW/NoPUGTv4_126X_mcRun3_2023_forPU65_v4-v2/2540000/01363ca6-a267-4d05-adda-18d4e6f374ad.root'),
 #     fileNames = cms.untracked.vstring('file:/eos/cms/store/mc/Run3Winter23Reco/SinglePionGun_E0p2to200/GEN-SIM-RECO/EpsilonPU_126X_mcRun3_2023_forPU65_v1-v2/2550000/007001ee-f0d5-4161-99ea-f286ad7136e6.root'),
@@ -166,7 +167,7 @@ from PhysicsTools.PatAlgos.tools.helpers import associatePatAlgosToolsTask
 associatePatAlgosToolsTask(process)
 
 #Setup FWK for multithreaded
-process.options.numberOfThreads = 1
+process.options.numberOfThreads = 36
 process.options.numberOfStreams = 0
 process.options.numberOfConcurrentLuminosityBlocks = 2
 process.options.eventSetup.numberOfConcurrentIOVs = 1


### PR DESCRIPTION
So, what's happening is:
(1) occasionally charged hadron is identified as PFMuon (perhaps punch-through?)
(2) this single particle gun sample gives anomalous looking event, because we are shooting only single pion. the pf post muon cleaning removes those pf muon.
(3) we basically find event with very low energy PF candidate leading to low ecal+hcal.

Somewhat ad-hoc solution for now: turn off PF muon post cleaning.